### PR TITLE
Add project documentation

### DIFF
--- a/MCCF/README.md
+++ b/MCCF/README.md
@@ -1,14 +1,8 @@
-# This repository contains code, data, and analysis related to Vietnam’s power sector, compiled as part of ongoing work at the Mekong Centre for Climate Finance. It supports exploratory and policy-relevant research at the intersection of energy, finance, and climate policy.
-# Focus Areas
-- Power generation and capacity expansion
-- Renewable integration and coal phase-out
-- Financial modelling of infrastructure assets
-- Policy risk analysis and Just Energy Transition
+# MCCF Package
 
+The `MCCF` package collects utilities used by the Mekong Centre for Climate Finance. It contains two main groups of code:
 
-## Structure
-- `data/` – Raw and processed datasets (non-sensitive)
-- `notebooks/` – Exploratory Jupyter notebooks and analysis scripts
-- `src/` – Reusable code modules and utilities
-- `outputs/` – Charts, tables, and visualisations for reports
-- `docs/` – Draft notes, documentation, and project outlines
+1. **PDP8 mapping tools (`MCCF/PDP8`)** – scripts for producing interactive maps of Vietnam's power projects and grid infrastructure.
+2. **API & translation helpers (`MCCF/API tools`)** – standalone scripts that integrate with Google Cloud and OpenAI for OCR and translation tasks.
+
+Most modules are intended to be executed directly rather than imported. See the repository [README](../README.md) for installation and usage instructions.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# MCCF Repository
+
+This repository hosts mapping utilities and translation tools developed for the Mekong Centre for Climate Finance. The code is organised under the `MCCF` Python package and includes data processing helpers for the PDP8 plan as well as scripts that integrate with Google Cloud and OpenAI APIs.
+
+## Key folders
+
+- `MCCF/PDP8/` – utilities for building interactive maps of Vietnam's power sector.
+- `MCCF/API tools/` – helpers for OCR and translation using Google APIs and optional GPT.
+
+A detailed description of each component is available in [docs/OVERVIEW.md](docs/OVERVIEW.md).
+
+## Setup
+
+Install dependencies using `pip install -r requirements.txt` or create the conda environment from `environment.yaml`.
+
+## Usage
+
+Mapping and API scripts are typically run directly, for example:
+
+```bash
+python MCCF/PDP8/create_map.py      # build power sector maps
+python 'MCCF/API tools/translation_script.py' --use-dictionary
+```
+
+Results are written to the `MCCF/PDP8/results` directory.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,0 +1,33 @@
+# Repository Overview
+
+This document summarises the code base and highlights the main modules.
+
+## PDP8 Mapping Utilities (`MCCF/PDP8`)
+
+These scripts generate interactive maps of Vietnam's power infrastructure using Folium and GeoPandas. Key components include:
+
+- **`create_map.py`** – builds various map layers (projects, substations, transmission lines) and writes HTML output.
+- **`map_utils.py`** – shared helpers for reading data sources, caching, and styling map features.
+- **`utils/`** – extraction tools for reading geo packages, PDF tables, and solar/wind data.
+- **`config.py`** – file paths for input datasets and output locations.
+
+Running `python MCCF/PDP8/create_map.py` produces HTML maps under `MCCF/PDP8/results`.
+
+## Translation & API Tools (`MCCF/API tools`)
+
+Scripts in this folder assist with translating spreadsheet content and processing OCR results.
+
+- **`translation_script.py`** – builds a custom Vietnamese translation dictionary from a CSV and can apply it to translate data.
+- **`apply_translation_dict.py`** – applies a prepared dictionary to a CSV for consistent translations.
+- **`translate_with_gcp_openai_v1_fixed.py`** – translates Excel sheets using Google Cloud Translate or optionally OpenAI GPT.
+- **`run_vision_ocr.py`** and **`vision_api.py`** – use Google Vision API to perform OCR on PDFs stored in Cloud Storage and translate the extracted text.
+
+These scripts depend on valid credentials for the respective APIs and are executed directly from the command line.
+
+## Additional Files
+
+- `Model_Translation_Dictionary.txt` – example output from the translation tools.
+- `requirements.txt` and `environment.yaml` – Python dependencies.
+- `setup.py` – packaging configuration exposing `mccf-map` as a console entry point.
+
+Use these documents together with the root [README](../README.md) to understand the repository structure.


### PR DESCRIPTION
## Summary
- add repository-level README outlining mapping and translation scripts
- document code layout under `docs/OVERVIEW.md`
- update package README with pointers to the new docs

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'deprecated' from 'typing_extensions')*

------
https://chatgpt.com/codex/tasks/task_e_6863d65e34e88329ae627754dc44ee34